### PR TITLE
Pass custom groups file name option

### DIFF
--- a/bin/api2html.js
+++ b/bin/api2html.js
@@ -40,6 +40,7 @@ program
     .option("-m, --summary", "use summary instead of operationId for TOC")
     .option("-b, --omitBody", "Omit top-level fake body parameter object")
     .option("-R, --raw", "Show raw schemas in samples, not example values")
+    .option("-g, --groups <groupsPath>", "the file where tag groups are defined, in JSON format")
     .parse(process.argv);
 
 if (program.args.length === 0) {
@@ -68,6 +69,10 @@ if (program.args.length === 0) {
     options.omitBody = program.omitBody || false;
     options.language_tabs = [];
     options.sample = !program.raw;
+
+    if (program.groups) {
+        options.tagGroups = JSON.parse(fs.readFileSync(program.groups, 'utf8'));
+    }
 
     // Default languages: All
     Object.getOwnPropertyNames(languageMap).forEach((lang) => {


### PR DESCRIPTION
Allow setting custom tag groups by reading a from a file where tag groups are defined.