### PR TITLE
Add PHP to supported Language Map

### DIFF
--- a/bin/api2html.js
+++ b/bin/api2html.js
@@ -19,7 +19,8 @@ const languageMap = {
     "ruby": "Ruby",
     "python": "Python",
     "java": "Java",
-    "go": "Go"
+    "go": "Go",
+    "php: "PHP"
 };
 
 const icons = {


### PR DESCRIPTION
I have an API that can be used by a variety of languages and it doesn't seem that I can specify PHP as a language. I believe this change will allow that?

As mentioned in Issue #18, it'd be nice to be able to specify a Widdershins config file instead to configure it instead of having to use `api2html` params.