### PR TITLE
Expose custom logo url configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Usage: api2html [options] <sourcePath>
     -o, --out <outputPath>          output path for the resulting HTML document
     -t, --theme <themeName>         theme to use (see https://highlightjs.org/static/demo/ for a list)
     -c, --customLogo <logoPath>     use custom logo at the respective path
+    -u, --customLogoUrl <logoURL>   url for the custom logo to point to
     -C, --customCss                 use custom css
     -P, --customCssPath <cssPath>   use custom css file
     -i, --includes <includesList>   comma-separated list of files to include

--- a/bin/api2html.js
+++ b/bin/api2html.js
@@ -35,7 +35,7 @@ program
     .option("-o, --out <outputPath>", "output path for the resulting HTML document")
     .option("-t, --theme <themeName>", "theme to use (see https://highlightjs.org/static/demo/ for a list)")
     .option("-c, --customLogo <logoPath>", "use custom logo at the respective path")
-    .option("-u, --customLogoUrl <logoURL>", "Url for the custom logo to point to")
+    .option("-u, --customLogoUrl <logoURL>", "url for the custom logo to point to")
     .option("-C, --customCss", "use custom css")
     .option("-P, --customCssPath <cssPath>", "use custom css file")
     .option("-i, --includes <includesList>", "comma-separated list of files to include")

--- a/bin/api2html.js
+++ b/bin/api2html.js
@@ -35,6 +35,7 @@ program
     .option("-o, --out <outputPath>", "output path for the resulting HTML document")
     .option("-t, --theme <themeName>", "theme to use (see https://highlightjs.org/static/demo/ for a list)")
     .option("-c, --customLogo <logoPath>", "use custom logo at the respective path")
+    .option("-u, --customLogoUrl <logoURL>", "Url for the custom logo to point to")
     .option("-C, --customCss", "use custom css")
     .option("-P, --customCssPath <cssPath>", "use custom css file")
     .option("-i, --includes <includesList>", "comma-separated list of files to include")
@@ -119,6 +120,11 @@ if (program.args.length === 0) {
     // Check for custom logo option
     if (program.customLogo) {
         shinOptions.logo = program.customLogo;
+
+        // Check for logo url option
+        if (program.customLogoUrl) {
+            shinOptions['logo-url'] = program.customLogoUrl;
+        }
     }
 
     // Check for custom css option


### PR DESCRIPTION
This PR exposes the shin option 'logo-url' in order to be able to define a url for the custom logo to point to.