### PR TITLE
Typo fix: convert from MD to HTML

### DIFF
--- a/bin/api2html.js
+++ b/bin/api2html.js
@@ -180,7 +180,7 @@ if (program.args.length === 0) {
                         process.exit(-1);
                     }
 
-                    console.log(chalk.green(icons.ok) + " Rendered HTML form markdown!");
+                    console.log(chalk.green(icons.ok) + " Rendered HTML from markdown!");
                     
                     if (customCss) {
                         html = html.replace (/\/\* place your custom CSS overrides here \*\//i, customCss);


### PR DESCRIPTION
Looks like there is a typo in console's log: the project is converting a markdown file, so it should be `from` rather than `form`